### PR TITLE
Fix None appearing in urn strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "workbench.colorCustomizations": {
+        "editorInfo.foreground": "#0080ff6a"
+    },
+    "conventionalCommits.scopes": [
+        "release"
+    ]
+}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,5 @@
 include *.sh
 include LICENSE
 include pytest.ini
+
+prune tests/

--- a/setup.py
+++ b/setup.py
@@ -11,66 +11,59 @@ import os
 
 from setuptools import find_packages, setup
 
-readme = open('README.md').read()
+readme = open("README.md").read()
 
-tests_require = [
-]
+tests_require = []
 
 extras_require = {
-    'tests': [
-        'pydocstyle',
-        'isort',
-        'check-manifest',
-        'pytest'
-    ],
+    "tests": ["pydocstyle", "isort", "check-manifest", "pytest"],
 }
 
 setup_requires = [
-    'pytest-runner>=3.0.0,<5',
+    "pytest-runner>=3.0.0,<5",
 ]
 
-install_requires = [
-]
+install_requires = []
 
-packages = find_packages(exclude="tests")
+packages = find_packages(exclude=["tests"])
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('urnparse', 'version.py'), 'rt') as fp:
+with open(os.path.join("urnparse", "version.py"), "rt") as fp:
     exec(fp.read(), g)
-    version = g['__version__']
+    version = g["__version__"]
 
 setup(
-    name='urnparse',
+    name="urnparse",
     version=version,
     description=__doc__,
     long_description=readme,
-    long_description_content_type='text/markdown',
-    license='MIT',
-    author='Miroslav Bauer @ CESNET',
-    author_email='bauer@cesnet.cz',
-    url='https://github.com/oarepo/urnparse',
+    long_description_content_type="text/markdown",
+    license="MIT",
+    author="Miroslav Bauer @ CESNET",
+    author_email="bauer@cesnet.cz",
+    url="https://github.com/oarepo/urnparse",
     packages=packages,
     zip_safe=False,
     include_package_data=True,
-    platforms='any',
+    platforms="any",
     entry_points={},
     extras_require=extras_require,
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Development Status :: 4 - Beta',
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Development Status :: 4 - Beta",
     ],
 )

--- a/tests/test_urn.py
+++ b/tests/test_urn.py
@@ -60,3 +60,9 @@ def test_urn():
 
     with pytest.raises(InvalidURNFormatError):
         URN8141.from_string('uri:tests#example.org')
+
+def test_urn_null_rfq():
+    nid = NSIdentifier('test')
+    nss = NSSString('example.org:resource:test%20space')
+    urn = URN8141(nid=nid, nss=nss)
+    assert str(urn) == "urn:test:example.org:resource:test%20space"

--- a/urnparse/__init__.py
+++ b/urnparse/__init__.py
@@ -155,7 +155,7 @@ class URN8141:
         """
         self._nid = nid
         self._nss = nss
-        self._rqf = rqf
+        self._rqf = rqf if rqf else RQFComponent('', '', '')
 
     @property
     def namespace_id(self) -> NSIdentifier:

--- a/urnparse/version.py
+++ b/urnparse/version.py
@@ -7,4 +7,4 @@
 
 """Python library for generating and parsing and RFC 8141 compliant uniform resource names (URN)."""
 
-__version__ = '0.2.0'
+__version__ = "0.2.1"


### PR DESCRIPTION
Firstly thanks for making a library for urns.

If no rqf is submitted to the constructor of URN8141, self._rqf defaults to None.
This is fine but when representing the urn, the None makes it into the string and it looks like:
`urn:mynid:mynssNone`

Since rqfs are optional according to the spec and also, I suspect, frequently not present. I think not submitting an rqf to the constructor should end up with the empty RQF('', '', ''), which represents itself as the null string and does not produce that unsightly "None".

An alternate way to do this same thing might be to allow None as a value for self._rqf but construct the representation such that a null _rqf results in no rqf suffix in _repr_()

Whaddya think?